### PR TITLE
support UV_KEYRING_SUBPROCESS env var

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -351,7 +351,7 @@ struct PipCompileArgs {
     ///
     /// Due to not having Python imports, only `--keyring-provider subprocess` argument is currently
     /// implemented `uv` will try to use `keyring` via CLI when this flag is used.
-    #[clap(long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum, env = "UV_KEYRING_PROVIDER")]
     keyring_provider: KeyringProvider,
 
     /// Locations to search for candidate distributions, beyond those found in the indexes.
@@ -525,7 +525,7 @@ struct PipSyncArgs {
     ///
     /// Function's similar to `pip`'s `--keyring-provider subprocess` argument,
     /// `uv` will try to use `keyring` via CLI when this flag is used.
-    #[clap(long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum, env = "UV_KEYRING_PROVIDER")]
     keyring_provider: KeyringProvider,
 
     /// The Python interpreter into which packages should be installed.
@@ -778,7 +778,7 @@ struct PipInstallArgs {
     ///
     /// Due to not having Python imports, only `--keyring-provider subprocess` argument is currently
     /// implemented `uv` will try to use `keyring` via CLI when this flag is used.
-    #[clap(long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum, env = "UV_KEYRING_PROVIDER")]
     keyring_provider: KeyringProvider,
 
     /// The Python interpreter into which packages should be installed.
@@ -1192,7 +1192,7 @@ struct VenvArgs {
     ///
     /// Due to not having Python imports, only `--keyring-provider subprocess` argument is currently
     /// implemented `uv` will try to use `keyring` via CLI when this flag is used.
-    #[clap(long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum, env = "UV_KEYRING_PROVIDER")]
     keyring_provider: uv_auth::KeyringProvider,
 
     /// Run offline, i.e., without accessing the network.


### PR DESCRIPTION
I'm opening this PR for my personal experimentation with https://github.com/astral-sh/uv/pull/2254

For my use case I prefer having a `UV_KEYRING_PROVIDER` env var parallel to `PIP_KEYRING_PROVIDER`, in analogy to `UV_EXTRA_INDEX_URL`::`PIP_EXTRA_INDEX_URL`.

This may not be relevant for https://github.com/astral-sh/uv/pull/2254, feel free to close if not relevant or if more discussion is required.

This PR enables

```
UV_EXTRA_INDEX_URL=https://<location>-python.pkg.dev/<project>/<gar_name>/simple UV_KEYRING_PROVIDER=subprocess uv pip install <package>               
```

when `keyrings.google_artifactregistry_auth` is available.